### PR TITLE
also ensure index for primary key other than id

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,6 @@ module.exports = function mongoAutoIndexHook(sails) {
       }
 
       _.forIn(model.attributes, function (attribute, attributeKey) {
-        if (attribute.primaryKey) {
-          return; // Sails autocreates primary key indexes
-        }
 
         if (attribute.unique) {
           indexes.push(

--- a/index.js
+++ b/index.js
@@ -7,14 +7,20 @@ module.exports = function mongoAutoIndexHook(sails) {
     var indexes = [];
 
     _.forIn(sails.models, function (model,modelKey) {
-      if(sails.config.connections[model.connection].adapter !== 'sails-mongo'){
+      if (modelKey == 'archive')
+        return;
+
+      mongodb = sails.config.datastores.default.adapter.mongodb
+      if(typeof mongodb !== 'undefined' && mongodb !== null){
         sails.log.verbose('sails-hook-mongo-auto-index: ' + 'skipping model ' + modelKey + ', not a sails-mongo model');
         return;
       }
 
       _.forIn(model.attributes, function (attribute, attributeKey) {
-
-        if (attribute.unique) {
+        if (attributeKey == 'id')
+          return;
+        org = attribute.autoMigrations
+        if (typeof org !== 'undefined' && org !== null ? org.unique : void 0) {
           indexes.push(
             {
               model: model,


### PR DESCRIPTION
Sails not auto creating index for primary key other than id. To ensure creating this type of index, the checking is removed in index.js. 

```
module.exports =
  autoPK: false
  attributes:
    email:
      type: 'email'
      unique: true
      required: true
      primaryKey: true
```

Please review.